### PR TITLE
Rever mill version to avoid incompatibility with 0.11

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -5,7 +5,7 @@ import de.tobiasroeser.mill.vcs.version._
 import mill._, scalalib._, publish._
 import mill.scalalib.api.Util.scalaNativeBinaryVersion
 
-val millVersions       = Seq("0.9.12", "0.10.12", "0.11.5")
+val millVersions       = Seq("0.9.12", "0.10.12", "0.11.0")
 val millBinaryVersions = millVersions.map(millBinaryVersion)
 
 def millBinaryVersion(millVersion: String) = scalaNativeBinaryVersion(millVersion)


### PR DESCRIPTION
Revert version bump avoiding incompatibility with older 0.11 versions.