### PR TITLE
Pass `pwd` as a parameter in `Upload.copyLauncher`

### DIFF
--- a/upload/src/io/github/alexarchambault/millnativeimage/upload/Upload.scala
+++ b/upload/src/io/github/alexarchambault/millnativeimage/upload/Upload.scala
@@ -259,12 +259,13 @@ object Upload {
     compress:       Boolean,
     suffix:         String = "",
     printChecksums: Boolean = true,
+    wd:             os.Path = os.pwd,
   ): os.Path = {
 
     if (printChecksums)
       Upload.printChecksums(nativeLauncher)
 
-    val path = os.Path(directory, os.pwd)
+    val path = os.Path(directory, wd)
     val dest =
       if (Properties.isWin && compress) {
         val dest0 = path / s"$name-$platformSuffix$suffix.zip"


### PR DESCRIPTION
This is needed for Mill 0.12 to pass `T.workspace`.
I didn't use the env variable here since this module is not Mill specific.
Note: This change is not binary compatible but source compatible.